### PR TITLE
Determine who is primary author and save e-mail in YAML field

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -47,6 +47,7 @@ def create_dict_4yaml() -> OrderedDict:
     pandoc_yaml_dict["artid"] = None
     pandoc_yaml_dict["author-meta"] = None
     pandoc_yaml_dict["title-meta"] = None
+    pandoc_yaml_dict["contact"] = ""
 
     return pandoc_yaml_dict
 

--- a/xml2yaml.py
+++ b/xml2yaml.py
@@ -286,15 +286,20 @@ def main(xml_filepath: Optional[str], year: Optional[str], volume: Optional[str]
         # increment auth idx
         auth_index += 1
 
-    # Primary contact from OJS data
-    ojs_id_of_primary = publication_data.attrib["primary_contact_id"]
-    # Loop over all authors and check who is primary contact
-    for a in data_dict["author"]:
-        if a["ojs-id"] == ojs_id_of_primary:
-            data_dict["contact_email"] = a["email"]
-            break
-    else:
-        data_dict["contact_email"] = "Adress of primary contact not found."
+    try:
+        # Primary contact from OJS data
+        ojs_id_of_primary = publication_data.attrib["primary_contact_id"]
+        # Loop over all authors and check who is primary contact
+        for a in data_dict["author"]:
+            if a["ojs-id"] == ojs_id_of_primary:
+                data_dict["contact_name"] = a["name"]
+                data_dict["contact_email"] = a["email"]
+                break
+    except KeyError:
+        # No information about primary contact found (e.g., because none 
+        # indicated in OJS)
+        data_dict["contact_name"] = ""
+        data_dict["contact_email"] = ""
 
 
         

--- a/xml2yaml.py
+++ b/xml2yaml.py
@@ -286,20 +286,13 @@ def main(xml_filepath: Optional[str], year: Optional[str], volume: Optional[str]
         # increment auth idx
         auth_index += 1
 
-    try:
-        # Primary contact from OJS data
-        ojs_id_of_primary = publication_data.attrib["primary_contact_id"]
-        # Loop over all authors and check who is primary contact
-        for a in data_dict["author"]:
-            if a["ojs-id"] == ojs_id_of_primary:
-                data_dict["contact_name"] = a["name"]
-                data_dict["contact_email"] = a["email"]
-                break
-    except KeyError:
-        # No information about primary contact found (e.g., because none 
-        # indicated in OJS)
-        data_dict["contact_name"] = ""
-        data_dict["contact_email"] = ""
+    # Primary contact from OJS data
+    ojs_id_of_primary = publication_data.attrib.get("primary_contact_id")
+    # Loop over all authors and check who is primary contact
+    for a in data_dict["author"]:
+        if a["ojs-id"] == ojs_id_of_primary:
+            data_dict["contact"] = {"name": a["name"], "email": a["email"]}
+            break
 
 
         

--- a/xml2yaml.py
+++ b/xml2yaml.py
@@ -206,6 +206,8 @@ def main(xml_filepath: Optional[str], year: Optional[str], volume: Optional[str]
     for author in authors_node:
         # init author dict
         author_dict = create_author_dict_4yaml()
+        # Store OJS ID of current author
+        author_dict["ojs-id"] = author.attrib["id"]
         # create full name
         given_name_node = author.find(".//{http://pkp.sfu.ca}givenname")
         family_name_node = author.find(".//{http://pkp.sfu.ca}familyname")
@@ -283,6 +285,17 @@ def main(xml_filepath: Optional[str], year: Optional[str], volume: Optional[str]
 
         # increment auth idx
         auth_index += 1
+
+    # Primary contact from OJS data
+    ojs_id_of_primary = publication_data.attrib["primary_contact_id"]
+    # Loop over all authors and check who is primary contact
+    for a in data_dict["author"]:
+        if a["ojs-id"] == ojs_id_of_primary:
+            data_dict["contact_email"] = a["email"]
+            break
+    else:
+        data_dict["contact_email"] = "Adress of primary contact not found."
+
 
         
     #### Create LaTeX for all authors in author dicts


### PR DESCRIPTION
Store each author's OJS ID and determine the OJS ID of the primary contact. Then check who is primary contact and output this e-mail address to YAML. 

This change is needed for the updated PDF layout which only gives the e-mail address of the primary contact.